### PR TITLE
fix(hantek-4032l): use std_cleanup instead of std_dev_clear

### DIFF
--- a/src/hardware/hantek-4032l/api.c
+++ b/src/hardware/hantek-4032l/api.c
@@ -246,7 +246,7 @@ static int dev_close(struct sr_dev_inst *sdi)
 
 static int cleanup(const struct sr_dev_driver *di)
 {
-	return std_dev_clear(di);
+	return std_cleanup(di);
 }
 
 static int config_get(uint32_t key, GVariant **data,


### PR DESCRIPTION
Fix segmentation fault on windows@mingw during device cleaning.
 - std_dev_clear could be overloaded for dev_clear, not for cleaning.

Signed-off-by: andy9a9 <andy@skyrain.eu>